### PR TITLE
Updated mset9.bat to Install Python

### DIFF
--- a/MSET9_installer_script/mset9.bat
+++ b/MSET9_installer_script/mset9.bat
@@ -32,4 +32,3 @@ if %errorlevel% EQU 0 python -3 mset9.py else (
       exit
     )
 )
-py -3 mset9.py

--- a/MSET9_installer_script/mset9.bat
+++ b/MSET9_installer_script/mset9.bat
@@ -5,57 +5,43 @@ chcp 65001 > nul
 py -V > nul 2>&1
 if %errorlevel% EQU 0 py -3 mset9.py & exit /B
 python -V > nul 2>&1
-if %errorlevel% EQU 0 python -3 mset9.py & exit /B else (
-    del p.exe 2> nul
-    echo Python not found. Do you want to install it? ^(yes or no^)
-    set /p pyPrompt="> " || set pyPrompt=n
-    set confirm=F    
+if %errorlevel% EQU 0 python mset9.py & exit /B else (
+  del p.exe 2> nul
+  echo Python not found. Do you want to install it? ^(yes or no^)
+  set /p pyPrompt="> "
+  set confirm=F
 
-    if %PyPrompt% EQU y set confirm=T
-    if %PyPrompt% EQU yes set confirm=T
+  if [%PyPrompt%] EQU [y] set confirm=T
+  if [%PyPrompt%] EQU [yes] set confirm=T
 
-    if %confirm% EQU T ( 
-      cls
-      echo Downloading...
+  if %confirm% EQU T ( 
+    cls
+    echo Downloading...
       
-      echo 6.1.7601> temp.txt & echo 6.2>> temp.txt & echo 6.3>> temp.txt & echo 10>> temp.txt
-      for /F "tokens=*" %%G in (temp.txt) do (
-        ver | findstr /i "%%G"> nul
-        if !errorlevel! EQU 0 if "%%G" EQU "6.1.7601 " (
-          powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'p.exe')"
-          goto :doneDownloading
-        ) else if "%%G" EQU "6.2 " (goto :newWin) else if "%%G" EQU "6.3 " (goto :newWin) else if "%%G" EQU "10" goto :newWin
-      )
-    ) else exit /B 
-)
+    echo 6.1.7601> temp.txt & echo 6.2>> temp.txt & echo 6.3>> temp.txt & echo 10>> temp.txt
+    for /F "tokens=*" %%G in (temp.txt) do (
+      ver | findstr /i "%%G"> nul
+      if !errorlevel! EQU 0 if "%%G" EQU "6.1.7601 " (
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'p.exe')"
+        goto :doneDownloading
+      ) else if "%%G" EQU "6.2 " (goto :newWin) else if "%%G" EQU "6.3 " (goto :newWin) else if "%%G" EQU "10" goto :newWin)) else exit /B)
 
-find python.exe > nul 2>&1
-if %errorlevel% NEQ 0 (
+if not exist p.exe (
   cls
-  echo Your Windows version is not supported. Please use a computer with at least Windows 7 + SP1 and rerun this script.
   del temp.txt
+  echo Your Windows version is not supported. Please use a computer with at least Windows 7 + SP1 and rerun this script.
   pause
-  exit /B
-)
+  exit /B)
 
 :newWin
  powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe -OutFile p.exe"
 
 :doneDownloading
-  if !errorlevel! NEQ 0 (
-    echo Error downloading Python. Rerun this file again or install Python manually.
-    pause
-    exit /B
-  )
-      
-echo  Done & echo Installing...
-python.exe /quiet PrependPath=1
-del python.exe & del temp.txt & echo  Done
-start cmd /K py %cd%\mset9.py
-exit
-
-py %cd%\mset9.py
-exit
-
-
-
+ del temp.txt
+ if !errorlevel! NEQ 0 echo Error downloading Python. Rerun this file again or download and install Python manually. & pause & exit /B    
+ echo  Done & echo Installing...
+ p.exe /quiet AppendPath=1
+ if %errorlevel% NEQ 0 echo Error installing Python. Rerun this file again or install Python manually. & pause & exit /B
+ del p.exe & echo  Done
+ echo Python installed successfully. Please rerun this script to open MSET9.
+ pause & exit

--- a/MSET9_installer_script/mset9.bat
+++ b/MSET9_installer_script/mset9.bat
@@ -1,12 +1,35 @@
 @echo off
 chcp 65001 > nul
-py -V > nul
-if %errorlevel% NEQ 0 (
-    echo Python 3 is not installed.
-    echo Please install Python 3 and try again.
-    echo https://www.python.org/downloads/
-    echo.
-    pause
-    exit
+
+py -V 2> nul
+if %errorlevel% EQU 0 py -3 mset9.py
+python -V 2> nul
+if %errorlevel% EQU 0 python -3 mset9.py else (
+    echo Python not found. Do you want to install it? (yes or no)
+    set /p pyPrompt="> "
+    set confirm=F    
+
+    if %PyPrompt% EQU y set confirm=T
+    if %PyPrompt% EQU yes set confirm=T
+
+    if %confirm% EQU T (
+      cls
+      echo Downloading...
+      
+      ver | findstr "6.1" > nul & :: 6.1 = Windows 7
+      if %errorlevel% EQU 0 (
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'python.exe')"
+      ) else (
+        powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe -OutFile python.exe"
+      )
+
+      echo  Done & echo Installing...
+      python.exe /quiet PrependPath=1
+      del python.exe & echo  Done
+      start cmd /K py %cd%\mset9.py
+      exit
+    ) else (
+      exit
+    )
 )
 py -3 mset9.py

--- a/MSET9_installer_script/mset9.bat
+++ b/MSET9_installer_script/mset9.bat
@@ -3,16 +3,26 @@ setlocal enabledelayedexpansion
 chcp 65001 > nul
 
 py -V > nul 2>&1
-if %errorlevel% EQU 0 py -3 mset9.py & exit /B
+if %errorlevel% EQU 0 (
+  py -3 mset9.py 
+  exit /B
+)
 python -V > nul 2>&1
-if %errorlevel% EQU 0 python mset9.py & exit /B else (
-  del p.exe 2> nul
+if %errorlevel% EQU 0 (
+  python mset9.py
+  exit /B 
+)
+  del p.exe temp.txt 2> nul
   echo Python not found. Do you want to install it? ^(yes or no^)
   set /p pyPrompt="> "
   set confirm=F
 
-  if [%PyPrompt%] EQU [y] set confirm=T
-  if [%PyPrompt%] EQU [yes] set confirm=T
+  if [%PyPrompt%] EQU [y] ( 
+    set confirm=T
+  )
+  if [%PyPrompt%] EQU [yes] (
+    set confirm=T
+  )
 
   if %confirm% EQU T ( 
     cls
@@ -21,27 +31,56 @@ if %errorlevel% EQU 0 python mset9.py & exit /B else (
     echo 6.1.7601> temp.txt & echo 6.2>> temp.txt & echo 6.3>> temp.txt & echo 10>> temp.txt
     for /F "tokens=*" %%G in (temp.txt) do (
       ver | findstr /i "%%G"> nul
-      if !errorlevel! EQU 0 if "%%G" EQU "6.1.7601 " (
-        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'p.exe')"
-        goto :doneDownloading
-      ) else if "%%G" EQU "6.2 " (goto :newWin) else if "%%G" EQU "6.3 " (goto :newWin) else if "%%G" EQU "10" goto :newWin)) else exit /B)
+      if !errorlevel! EQU 0 (
+        if "%%G" EQU "6.1.7601 " (
+          powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'p.exe')"
+          goto :doneDownloading
+        )
+      ) else (
+        if "%%G" EQU "6.2 " (
+          goto :newWin
+        ) else (
+          if "%%G" EQU "6.3 " (
+            goto :newWin
+          ) else (
+            if "%%G" EQU "10" (
+              goto :newWin
+            )
+          ) 
+        )
+      )
+    ) 
+  ) else (
+    exit /B
+  )
 
 if not exist p.exe (
   cls
   del temp.txt
   echo Your Windows version is not supported. Please use a computer with at least Windows 7 + SP1 and rerun this script.
   pause
-  exit /B)
+  exit /B
+  )
 
 :newWin
- powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe -OutFile p.exe"
+ powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe', 'p.exe')"
 
 :doneDownloading
- del temp.txt
- if !errorlevel! NEQ 0 echo Error downloading Python. Rerun this file again or download and install Python manually. & pause & exit /B    
- echo  Done & echo Installing...
- p.exe /quiet AppendPath=1
- if %errorlevel% NEQ 0 echo Error installing Python. Rerun this file again or install Python manually. & pause & exit /B
- del p.exe & echo  Done
- echo Python installed successfully. Please rerun this script to open MSET9.
- pause & exit
+  if !errorlevel! NEQ 0 (
+    echo Error downloading Python. Rerun this file again or download and install Python manually.
+    pause
+    exit /B    
+  )
+  echo  Done 
+  echo Installing...
+  p.exe /quiet AppendPath=1
+  if %errorlevel% NEQ 0 (
+    echo Error installing Python. Rerun this file again or install Python manually.
+    pause 
+    exit /B
+  )
+  del p.exe temp.txt
+  echo  Done
+  echo Python installed successfully. Please rerun this script to open MSET9.
+  pause 
+  exit

--- a/MSET9_installer_script/mset9.bat
+++ b/MSET9_installer_script/mset9.bat
@@ -5,8 +5,8 @@ chcp 65001 > nul
 py -V > nul 2>&1
 if %errorlevel% EQU 0 py -3 mset9.py & exit /B
 python -V > nul 2>&1
-if %errorlevel% EQU 0 python -3 mset9.py else (
-    
+if %errorlevel% EQU 0 python -3 mset9.py & exit /B else (
+    del p.exe 2> nul
     echo Python not found. Do you want to install it? ^(yes or no^)
     set /p pyPrompt="> " || set pyPrompt=n
     set confirm=F    
@@ -14,18 +14,19 @@ if %errorlevel% EQU 0 python -3 mset9.py else (
     if %PyPrompt% EQU y set confirm=T
     if %PyPrompt% EQU yes set confirm=T
 
-    if !confirm! EQU F exit /B 
+    if %confirm% EQU T ( 
       cls
       echo Downloading...
       
-    echo 6.1.7601> temp.txt & echo 6.2>> temp.txt & echo 6.3>> temp.txt & echo 10>> temp.txt
-    for /F "tokens=*" %%G in (temp.txt) do (
-      ver | findstr /i "%%G"> nul
-      if !errorlevel! EQU 0 if "%%G" EQU "6.1.7601 " (
-        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'python.exe')"
-        goto :doneDownloading
-      ) else if "%%G" EQU "6.2 " (goto :newWin) else if "%%G" EQU "6.3 " (goto :newWin) else if "%%G" EQU "10" goto :newWin
-    )
+      echo 6.1.7601> temp.txt & echo 6.2>> temp.txt & echo 6.3>> temp.txt & echo 10>> temp.txt
+      for /F "tokens=*" %%G in (temp.txt) do (
+        ver | findstr /i "%%G"> nul
+        if !errorlevel! EQU 0 if "%%G" EQU "6.1.7601 " (
+          powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'p.exe')"
+          goto :doneDownloading
+        ) else if "%%G" EQU "6.2 " (goto :newWin) else if "%%G" EQU "6.3 " (goto :newWin) else if "%%G" EQU "10" goto :newWin
+      )
+    ) else exit /B 
 )
 
 find python.exe > nul 2>&1
@@ -38,7 +39,7 @@ if %errorlevel% NEQ 0 (
 )
 
 :newWin
- powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe -OutFile python.exe"
+ powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe -OutFile p.exe"
 
 :doneDownloading
   if !errorlevel! NEQ 0 (
@@ -52,3 +53,9 @@ python.exe /quiet PrependPath=1
 del python.exe & del temp.txt & echo  Done
 start cmd /K py %cd%\mset9.py
 exit
+
+py %cd%\mset9.py
+exit
+
+
+

--- a/MSET9_installer_script/mset9.bat
+++ b/MSET9_installer_script/mset9.bat
@@ -1,34 +1,54 @@
 @echo off
+setlocal enabledelayedexpansion
 chcp 65001 > nul
 
-py -V 2> nul
-if %errorlevel% EQU 0 py -3 mset9.py
-python -V 2> nul
+py -V > nul 2>&1
+if %errorlevel% EQU 0 py -3 mset9.py & exit /B
+python -V > nul 2>&1
 if %errorlevel% EQU 0 python -3 mset9.py else (
-    echo Python not found. Do you want to install it? (yes or no)
-    set /p pyPrompt="> "
+    
+    echo Python not found. Do you want to install it? ^(yes or no^)
+    set /p pyPrompt="> " || set pyPrompt=n
     set confirm=F    
 
     if %PyPrompt% EQU y set confirm=T
     if %PyPrompt% EQU yes set confirm=T
 
-    if %confirm% EQU T (
+    if !confirm! EQU F exit /B 
       cls
       echo Downloading...
       
-      ver | findstr "6.1" > nul & :: 6.1 = Windows 7
-      if %errorlevel% EQU 0 (
+    echo 6.1.7601> temp.txt & echo 6.2>> temp.txt & echo 6.3>> temp.txt & echo 10>> temp.txt
+    for /F "tokens=*" %%G in (temp.txt) do (
+      ver | findstr /i "%%G"> nul
+      if !errorlevel! EQU 0 if "%%G" EQU "6.1.7601 " (
         powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.python.org/ftp/python/3.8.10/python-3.8.10.exe', 'python.exe')"
-      ) else (
-        powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe -OutFile python.exe"
-      )
-
-      echo  Done & echo Installing...
-      python.exe /quiet PrependPath=1
-      del python.exe & echo  Done
-      start cmd /K py %cd%\mset9.py
-      exit
-    ) else (
-      exit
+        goto :doneDownloading
+      ) else if "%%G" EQU "6.2 " (goto :newWin) else if "%%G" EQU "6.3 " (goto :newWin) else if "%%G" EQU "10" goto :newWin
     )
 )
+
+find python.exe > nul 2>&1
+if %errorlevel% NEQ 0 (
+  cls
+  echo Your Windows version is not supported. Please use a computer with at least Windows 7 + SP1 and rerun this script.
+  del temp.txt
+  pause
+  exit /B
+)
+
+:newWin
+ powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.12.2/python-3.12.2-amd64.exe -OutFile python.exe"
+
+:doneDownloading
+  if !errorlevel! NEQ 0 (
+    echo Error downloading Python. Rerun this file again or install Python manually.
+    pause
+    exit /B
+  )
+      
+echo  Done & echo Installing...
+python.exe /quiet PrependPath=1
+del python.exe & del temp.txt & echo  Done
+start cmd /K py %cd%\mset9.py
+exit


### PR DESCRIPTION
Rather than telling Windows users to install Python themselves, I've updated the .bat to do it for them. This has not been tested on Windows 7, but unless i did something wrong it should work.

It does the following:

- Checks if `python` or `py` exists, and runs them it they do (fixes #33)
- If not found, it asks user if they want to install Python
- If yes, it downloads and installs the appropriate Python version (based on their Windows version) and opens and runs `mset9.py` in a new cmd instance

This hopefully will cut out the middleman of users downloading Python themselves, which some users can get confused on.